### PR TITLE
Improve default security of Electron applications

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -9,7 +9,7 @@ function createWindow() {
 		height: 600,
 		minHeight: 550,
 		webPreferences: {
-			nodeIntegration: true,
+			contextIsolation: true,
 			spellcheck: false
 		},
 		autoHideMenuBar: true,


### PR DESCRIPTION
- Removed the `nodeIntregation` flag because it's insecure and we don't need it anyway.
- Enabled the web render context isolation to lock down further the powerful electron APIs (in case we need it).
  Read more here: https://github.com/electron/electron/blob/master/docs/tutorial/context-isolation.md