### PR TITLE
Removed no longer working link to original vertx-eventbus.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ Original source code of eventbus handler once existed here:
 
 - https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/client/vertx-eventbus.js
 
-**that no longer is the case.** Where it is now, is a mystery (please report any findings here :wink:). It was, however, last seen in
-
-- https://github.com/vert-x3/vertx-web/commit/0c257b111a13597618c92d6482253f6422b3536d#diff-def126407e3ad10b16f833b7ce3b456cf88491796a22d0f8b5965327ded79b5c
-
 and NOT here:
 
 - https://github.com/vert-x3/vertx-stack
 - https://github.com/vert-x3/vertx-bus-bower
+
+**that no longer is the case.** Where it is now, is a mystery (please report any findings here :wink:). It was, however, last seen in
+
+- https://github.com/vert-x3/vertx-web/commit/0c257b111a13597618c92d6482253f6422b3536d#diff-def126407e3ad10b16f833b7ce3b456cf88491796a22d0f8b5965327ded79b5c


### PR DESCRIPTION
Apparently, commit https://github.com/vert-x3/vertx-web/commit/0c257b111a13597618c92d6482253f6422b3536d#diff-def126407e3ad10b16f833b7ce3b456cf88491796a22d0f8b5965327ded79b5c moved the npm bits out of their repo.

I have no idea where it is now (a quick search gave me no further information than "it got moved out of this repo"). To be blunt, I also don't really care (after initially having spent far too much time finding this location, I can't find the motivation to go on another scavenger hunt for the new location...)

This PR updates our `README.md` to reflect the current situation. If anyone finds the new location in the future, please create another PR or comment here 😉 .

And, should anyone from VertX read this: Please, please (!) don't just say "moved out of this repo" in your commit messages, but also provide the new location (or, if it got removed entirely, say so as well).