### PR TITLE
fix(telestion-client-template): Disable `<StrictMode />` in default template to ensure compatibility with React Spectrum

### DIFF
--- a/packages/telestion-client-template/template/src/index.tsx.ejs
+++ b/packages/telestion-client-template/template/src/index.tsx.ejs
@@ -1,12 +1,9 @@
-import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 
 import { App } from './components/app';
 import './index.css';
 
 ReactDOM.render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
+	<App />,
 	document.getElementById('root')
 );


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Removed `<StrictMode />` in template since it's not fully compatible with React Spectrum and can lead to easy-to-debug errors

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
