### PR TITLE
Add `useDesktopNotifications()` hook to `telestion-client-common` to implement core Notification APIs

### DIFF
--- a/packages/telestion-client-common/src/hooks/index.ts
+++ b/packages/telestion-client-common/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './utils';
 
 export * from './use-dependency-timeout';
 export * from './use-spectrum-color';
+export * from './use-desktop-notifications';

--- a/packages/telestion-client-common/src/hooks/use-desktop-notifications.ts
+++ b/packages/telestion-client-common/src/hooks/use-desktop-notifications.ts
@@ -1,0 +1,76 @@
+import { useLogger, useNotifications } from '@wuespace/telestion-client-core';
+import { useEffect } from 'react';
+
+/**
+ * Enables and handles the usage of native desktop notifications for implementing the
+ * `@wuespace/telestion-client-core`'s abstract `useNotifications` APIs.
+ *
+ * Call this hook once in your `app.tsx` and everything else gets handled for you.
+ *
+ * @see {@link @wuespace/telestion-client-core#useNotifications}
+ *
+ * @example
+ * ```ts
+ * // [...]
+ * import { useDesktopNotifications } from '@wuespace/telestion-client-common';
+ *
+ * export function App() {
+ *     useDesktopNotifications();
+ *
+ *     useEventBusManager();
+ *     // [...]
+ *
+ *     return <TelestionClient>
+ *         // [...]
+ *     </TelestionClient>
+ * }
+ * ```
+ */
+export function useDesktopNotifications(): void {
+	const logger = useLogger('Desktop Notifications');
+
+	const [notifications, isMuted, dismiss] = useNotifications(
+		notificationStore => [
+			notificationStore.notifications,
+			notificationStore.isMuted,
+			notificationStore.dismiss
+		]
+	);
+
+	// Request permission on launch
+	useEffect(() => {
+		if (window.Notification.permission !== 'granted') {
+			logger.debug(
+				'Requesting desktop notification permission since ' +
+					'Notification.permission is not "granted"'
+			);
+			window.Notification.requestPermission()
+				.then(() => logger.success('Permission granted'))
+				.catch(e => logger.warn('Permission got denied. Details:', e));
+		}
+	}, []);
+
+	// Send desktop notifications for new notifications in notification store
+	useEffect(() => {
+		if (window.Notification.permission !== 'granted') {
+			logger.debug(
+				'Tried sending new notifications, but permission is not granted. Aborting.'
+			);
+			return;
+		}
+
+		const notificationsToShow = notifications.filter(n => !n.isDismissed);
+
+		if (!isMuted && notificationsToShow.length > 0) {
+			notificationsToShow.forEach(notification => {
+				logger.debug('Sending desktop notification for', notification);
+
+				// eslint-disable-next-line no-new
+				new window.Notification(notification.message, {
+					body: notification.description
+				});
+			});
+			dismiss(notificationsToShow);
+		}
+	}, [notifications, isMuted, dismiss]);
+}

--- a/packages/telestion-client-common/src/hooks/use-desktop-notifications.ts
+++ b/packages/telestion-client-common/src/hooks/use-desktop-notifications.ts
@@ -1,5 +1,24 @@
-import { useLogger, useNotifications } from '@wuespace/telestion-client-core';
+import {
+	NotificationState,
+	useLogger,
+	useNotifications
+} from '@wuespace/telestion-client-core';
 import { useEffect } from 'react';
+import { StateSelector } from 'zustand';
+
+// static selector
+const notificationSelector: StateSelector<
+	NotificationState,
+	[
+		NotificationState['notifications'],
+		NotificationState['isMuted'],
+		NotificationState['dismiss']
+	]
+> = notificationStore => [
+	notificationStore.notifications,
+	notificationStore.isMuted,
+	notificationStore.dismiss
+];
 
 /**
  * Enables and handles the usage of native desktop notifications for implementing the
@@ -29,13 +48,8 @@ import { useEffect } from 'react';
 export function useDesktopNotifications(): void {
 	const logger = useLogger('Desktop Notifications');
 
-	const [notifications, isMuted, dismiss] = useNotifications(
-		notificationStore => [
-			notificationStore.notifications,
-			notificationStore.isMuted,
-			notificationStore.dismiss
-		]
-	);
+	const [notifications, isMuted, dismiss] =
+		useNotifications(notificationSelector);
 
 	// Request permission on launch
 	useEffect(() => {

--- a/packages/telestion-client-template/template/src/components/app.tsx.ejs
+++ b/packages/telestion-client-template/template/src/components/app.tsx.ejs
@@ -6,7 +6,7 @@ import {
 	DashboardPage,
 	NotFoundPage,
 	useUserConfig,
-    useDesktopNotifications,
+	useDesktopNotifications,
 	commonWidgets
 } from "@wuespace/telestion-client-common";
 
@@ -29,7 +29,7 @@ export function App() {
 	}, [set]);
 
 	// Enable native Desktop notifications. Comment this line out
-    // to disable them.
+	// to disable them.
 	useDesktopNotifications();
 
 	return (

--- a/packages/telestion-client-template/template/src/components/app.tsx.ejs
+++ b/packages/telestion-client-template/template/src/components/app.tsx.ejs
@@ -6,6 +6,7 @@ import {
 	DashboardPage,
 	NotFoundPage,
 	useUserConfig,
+    useDesktopNotifications,
 	commonWidgets
 } from "@wuespace/telestion-client-common";
 
@@ -26,6 +27,10 @@ export function App() {
 		// apply user config once
 		set(userConfig);
 	}, [set]);
+
+	// Enable native Desktop notifications. Comment this line out
+    // to disable them.
+	useDesktopNotifications();
 
 	return (
 		<TelestionClient


### PR DESCRIPTION
This Pull Reuqest adds hook to common that enables handling of the core's `useNotifications` APIs by implementing them with native desktop notifiacations. The PR also adjusts the template to use this hook by default.

- Closes: #1171

Yes, I have signed the CLA