### PR TITLE
fix(cli): Fix native builds not running when there are linter warnings while compiling the React app

### DIFF
--- a/packages/telestion-client-cli/src/lib/build/compile-react-app.js
+++ b/packages/telestion-client-cli/src/lib/build/compile-react-app.js
@@ -23,11 +23,11 @@ async function compileReactApp() {
 			if (
 				message[0] &&
 				message[0].includes &&
-				message[0].includes('Compiled successfully.')
+				/Compiled .*\./.test(message[0]) // 'Compiled successfully.' or 'Compiled with warnings.'
 			) {
 				// Set a timeout to allow for final messages to get printed before continuing
-				// while 'Compiled successfully.' is the string that easiest to detect, a
-				// few lines follow it in the log.
+				// while 'Compiled successfully.' / 'Compiled with warnings.' is the string that easiest to 
+				// detect, a few lines follow it in the log.
 				setTimeout(resolve, 250);
 			}
 		};

--- a/packages/telestion-client-cli/src/lib/build/compile-react-app.js
+++ b/packages/telestion-client-cli/src/lib/build/compile-react-app.js
@@ -26,7 +26,7 @@ async function compileReactApp() {
 				/Compiled .*\./.test(message[0]) // 'Compiled successfully.' or 'Compiled with warnings.'
 			) {
 				// Set a timeout to allow for final messages to get printed before continuing
-				// while 'Compiled successfully.' / 'Compiled with warnings.' is the string that easiest to 
+				// while 'Compiled successfully.' / 'Compiled with warnings.' is the string that easiest to
 				// detect, a few lines follow it in the log.
 				setTimeout(resolve, 250);
 			}


### PR DESCRIPTION
Closes: #970